### PR TITLE
Handle empty columns array in onLayoutChange

### DIFF
--- a/src/ui/Parser/Parser.tsx
+++ b/src/ui/Parser/Parser.tsx
@@ -130,8 +130,16 @@ export default class ParserApp extends React.Component<Props, State> {
 
 
   onLayoutChange = (event:React.ChangeEvent<HTMLInputElement>, row: number): void => {
-    const newCol:number[] = this.state.columns.map((v: number, k: number): number => {if (k==row) {return Number(event.target.value)} return v})
-    this.setState({...this.state,columns: newCol})
+    const value = Number(event.target.value)
+    this.setState(({ rows, columns: oldColumns }) => {
+      let columns = []
+      for (let i = 0; i < rows; i++) {
+        const original = oldColumns[i] || 0
+        columns.push(i === row ? value : original)
+      }
+
+      return { columns }
+    })
   }
 
   selectLayout = (event:React.ChangeEvent<HTMLSelectElement>): void => {


### PR DESCRIPTION
Fixes https://github.com/bmcgavin/zmk-parser/issues/10

`state.columns` is initialized to an empty array, but the array is never modified when the number of rows changes. This means that `onLayoutChange` tries to map values of an empty array instead creating an array of length `state.rows`.

It might be more appropriate for the event handler tied to the `rows` input to resize the `columns` array but I didn't want to turn this into a refactor. Worth noting that this simple solution means that the columns array is untouched even when removing rows which may have unintended side effects.